### PR TITLE
Add support for flashless or ramless devices

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,12 +143,17 @@ fn main() {
                 families.last_mut().unwrap()
             };
 
+            let mut memory_map: Vec<MemoryRegion> = Vec::new();
+            if let Some(mem) = ram {
+                memory_map.push(MemoryRegion::Ram(mem));
+            }
+            if let Some(mem) = flash {
+                memory_map.push(MemoryRegion::Flash(mem));
+            }
+
             family.variants.push(Chip {
                 name: device_name,
-                memory_map: vec![
-                    MemoryRegion::Ram(ram.unwrap()),
-                    MemoryRegion::Flash(flash.unwrap()),
-                ],
+                memory_map,
             });
         }
 


### PR DESCRIPTION
For exemple NXP LPC18x0 and LPC43x0 do not have any internal flash,
they instead support various kind of external flash.