### PR TITLE
Check wether input and output dir exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,11 @@ fn main() {
     let out_dir = options.output_dir;
 
     if !in_dir.exists() {
-        panic!("No such file or directory {:?}", in_dir);
+        eprintln!("No such file or directory {:?}", in_dir);
+        std::process::exit(1);
     } else if !out_dir.exists() {
-        panic!("No such file or directory {:?}", out_dir);
+        eprintln!("No such file or directory {:?}", out_dir);
+        std::process::exit(1);
     }
 
     let mut families = Vec::<ChipFamily>::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,7 @@ fn main() {
 
     if !in_dir.exists() {
         panic!("No such file or directory {:?}", in_dir);
-    }
-    else if !out_dir.exists() {
+    } else if !out_dir.exists() {
         panic!("No such file or directory {:?}", out_dir);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,13 @@ fn main() {
     let in_dir = options.input_dir;
     let out_dir = options.output_dir;
 
+    if !in_dir.exists() {
+        panic!("No such file or directory {:?}", in_dir);
+    }
+    else if !out_dir.exists() {
+        panic!("No such file or directory {:?}", out_dir);
+    }
+
     let mut families = Vec::<ChipFamily>::new();
     // Look for the .pdsc file in the given dir and it's child directories.
     let generation_result = visit_dirs(Path::new(&in_dir), &mut |pdsc, mut archive| {


### PR DESCRIPTION
If the output directory does not exist target-gen will spend some time
generating the yml files just to panic in the end because it can't open
the output directory. If the input directory was mistyped you won't even
get an error, it just exits cleanly without doing anything -> Instead panic in
the beginning!