### PR TITLE
Ensure algorithm names always lower case (#23)

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -137,7 +137,7 @@ where
 
         let flash_algorithm_names: Vec<_> = variant_flash_algorithms
             .iter()
-            .map(|fa| fa.name.clone().to_lowercase())
+            .map(|fa| fa.name.to_string())
             .collect();
 
         for fa in variant_flash_algorithms {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -101,7 +101,7 @@ pub fn extract_flash_algo(
         .unwrap()
         .to_str()
         .unwrap()
-        .to_owned()
+        .to_lowercase()
         .into();
     algo.default = default;
     algo.data_section_offset = algorithm_binary.data_section.start;


### PR DESCRIPTION
Always keep the names lower case as they are based on filenames
which where the casing might not be desired.