### PR TITLE
Sort FlashRegions and always use the first one in the address space

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -370,8 +370,7 @@ pub(crate) fn get_ram(device: &Device) -> Option<RamRegion> {
 pub(crate) fn get_flash(device: &Device) -> Option<FlashRegion> {
     let mut regions = Vec::new();
     for memory in device.memories.0.values() {
-        if memory.default && memory.access.read && memory.access.execute && !memory.access.write
-        {
+        if memory.default && memory.access.read && memory.access.execute && !memory.access.write {
             regions.push(FlashRegion {
                 range: memory.start as u32..memory.start as u32 + memory.size as u32,
                 is_boot_memory: memory.startup,


### PR DESCRIPTION
This matches the behaviour for RAM regions introduced in #20, but we don't merge them in case different algorithms are needed for different contiguous regions or something.

Before this PR, regenerating a target file from a pack was non-deterministic, as the sort order of the flashes was random. This way at least we are likely to always select the flash region you need to load the start of your firmware into (even if we don't get the entire flash), and the generated files are always the same.